### PR TITLE
Add node type indicator, and declared all node types

### DIFF
--- a/src/node/element.rs
+++ b/src/node/element.rs
@@ -69,6 +69,10 @@ macro_rules! impl_elements {
 
                         construction
                     }
+
+                    fn get_node_type(&self) -> isize {
+                        1 // Element node type is 1
+                    }
                 }
 
                 impl AnyElement for $ty {}

--- a/src/node/element.rs
+++ b/src/node/element.rs
@@ -71,10 +71,6 @@ macro_rules! impl_elements {
                         construction
                     }
 
-                    fn as_any(&self) -> &dyn Any {
-                        self
-                    }
-                
                     fn get_node_type(&self) -> isize {
                         1 // Element node type is 1
                     }

--- a/src/node/element.rs
+++ b/src/node/element.rs
@@ -3,6 +3,7 @@
 
 use downcast_rs::DowncastSync;
 use paste::paste;
+use std::any::Any;
 
 crate::use_behaviors!(node, sandbox_member);
 use crate::internal_prelude::*;
@@ -70,6 +71,10 @@ macro_rules! impl_elements {
                         construction
                     }
 
+                    fn as_any(&self) -> &dyn Any {
+                        self
+                    }
+                
                     fn get_node_type(&self) -> isize {
                         1 // Element node type is 1
                     }

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -19,14 +19,28 @@ pub mod element;
 /// An input event
 pub struct InputEvent {}
 
+#[derive(Copy, Clone)]
+enum NodeType {
+    Element = 1,
+    Attribute = 2,
+    Text = 3,
+    CDataSection = 4,
+    ProcessingInstruction = 7,
+    Comment = 8,
+    Document = 9,
+    DocumentType = 10,
+    DocumentFragment = 11,
+}
+
 /// A base trait for all common node types
 pub trait AnyNode: DowncastSync + SandboxMemberBehavior + NodeBehavior {
     /// Clones node according to Node.cloneNode()
     fn clone_node(&self) -> Arc<dyn AnyNode>;
 
-    /// Returns the node type, as defuned in https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType
+    /// Returns the node type, as defined in https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType
     fn get_node_type(&self) -> isize;
 }
+
 impl_downcast!(sync AnyNode);
 
 macro_rules! impl_nodes {
@@ -58,7 +72,7 @@ macro_rules! impl_nodes {
 
                     pub(crate) storage: $storage,
 
-                    node_type: isize,
+                    node_type: NodeType,
                 }
             }
 
@@ -94,7 +108,7 @@ macro_rules! impl_nodes {
                     }
 
                     fn get_node_type(&self) -> isize {
-                        self.node_type
+                        self.node_type as isize
                     }
                 }
             }
@@ -120,7 +134,7 @@ impl_nodes! {
         storage: (),
         blurb: "Element",
         link: "Element",
-        node_type: 1,
+        node_type: NodeType::Element,
         impl {}
     )
     (
@@ -128,7 +142,7 @@ impl_nodes! {
         storage: (),
         blurb: "attr (attribute)",
         link: "Attr",
-        node_type: 2,
+        node_type: NodeType::Attribute,
         impl {}
     )
     (
@@ -136,7 +150,7 @@ impl_nodes! {
         storage: TextNodeStorage,
         blurb: "text",
         link: "Text",
-        node_type: 3,
+        node_type: NodeType::Text,
         impl {}
     )
     (
@@ -144,7 +158,7 @@ impl_nodes! {
         storage: (),
         blurb: "CDATASection",
         link: "CDATASection",
-        node_type: 4,
+        node_type: NodeType::CDataSection,
         impl {}
     )
     (
@@ -152,7 +166,7 @@ impl_nodes! {
         storage: () /* or ProcessingInstructiNodeStorage */,
         blurb: "ProcessingInstruction",
         link: "ProcessingInstruction",
-        node_type: 7,
+        node_type: NodeType::ProcessingInstruction,
         impl {}
     )
     (
@@ -160,7 +174,7 @@ impl_nodes! {
         storage: () /* or CommentNodeStorage */,
         blurb: "Comment",
         link: "Comment",
-        node_type: 8,
+        node_type: NodeType::Comment,
         impl {}
     )
     (
@@ -168,7 +182,7 @@ impl_nodes! {
         storage: DocumentStorage,
         blurb: "document",
         link: "Document",
-        node_type: 9,
+        node_type: NodeType::Document,
         impl {
             /// Creates a text node.
             pub fn create_text_node(&self, text: String) -> Arc<TextNode> {
@@ -181,7 +195,7 @@ impl_nodes! {
         storage: () /* or DocumentTypeNodeStorage */,
         blurb: "DocumentType",
         link: "DocumentType",
-        node_type: 10,
+        node_type: NodeType::DocumentType,
         impl {}
     )
     (
@@ -189,7 +203,7 @@ impl_nodes! {
         storage: () /* or DocumentFragmentNodeStorage */,
         blurb: "DocumentFragment",
         link: "DocumentFragment",
-        node_type: 11,
+        node_type: NodeType::DocumentFragment,
         impl {}
     )
 }

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -3,7 +3,6 @@
 
 use downcast_rs::DowncastSync;
 use paste::paste;
-use std::any::Any;
 
 use crate::internal_prelude::*;
 
@@ -22,24 +21,15 @@ pub struct InputEvent {}
 
 #[derive(Copy, Clone)]
 /// Node type, as defined in https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType
-pub enum NodeType {
-    /// Element node
+pub(crate) enum NodeType {
     Element = 1,
-    ///  node
     Attribute = 2,
-    ///  node
     Text = 3,
-    ///  node
     CDataSection = 4,
-    ///  node
     ProcessingInstruction = 7,
-    ///  node
     Comment = 8,
-    ///  node
     Document = 9,
-    ///  node
     DocumentType = 10,
-    ///  node
     DocumentFragment = 11,
 }
 
@@ -47,9 +37,6 @@ pub enum NodeType {
 pub trait AnyNode: DowncastSync + SandboxMemberBehavior + NodeBehavior {
     /// Clones node according to Node.cloneNode()
     fn clone_node(&self) -> Arc<dyn AnyNode>;
-
-    /// Allows downcasting to concreate node type
-    fn as_any(&self) -> &dyn Any;
 
     /// Returns the node type, as defined in https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType
     fn get_node_type(&self) -> isize;
@@ -121,10 +108,6 @@ macro_rules! impl_nodes {
                         construction
                     }
 
-                    fn as_any(&self) -> &dyn Any {
-                        self
-                    }
-                
                     fn get_node_type(&self) -> isize {
                         self.node_type as isize
                     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -59,7 +59,7 @@ fn test_text_node() {
     let _doc = test_node_creation!(TextNode, NodeType::Text, TextNodeStorage {text: "test".to_owned()});
 
     let node = _doc.first_child().unwrap();
-    let node = AnyNode::as_any(node.as_ref()).downcast_ref::<TextNode>().unwrap();
+    let node = node.downcast_ref::<TextNode>().unwrap();
 
     assert_eq!(node.get_text().unwrap(), "test".to_owned());
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -5,9 +5,14 @@ use std::sync::Arc;
 use crate::behavior::node::NodeBehavior;
 use crate::config::ScreenMetrics;
 use crate::node::element::HtmlHtmlElement;
-use crate::sandbox::Sandbox;
+use crate::node::{ AnyNode,
+    AttrNode, CDataSectionNode, CommentNode, Document, DocumentFragmentNode, DocumentTypeNode,
+    ElementNode, NodeType, ProcessingInstructionNode, TextNode,
+};
+use crate::node::TextNodeStorage;
 
-use crate::node::AnyNode;
+use crate::sandbox::Sandbox;
+use paste::paste;
 
 #[test]
 fn it_works() {
@@ -19,3 +24,68 @@ fn it_works() {
     doc.append_child(document_element);
     assert_eq!(doc.child_nodes().length(), 1);
 }
+
+macro_rules! test_node_creation {
+    ($ty: ty, $node_type: expr, $storage: expr) => {{
+        let metrics: ScreenMetrics = Default::default();
+        let sbox = Sandbox::new(metrics);
+        let doc = sbox.clone().window().document();
+        let weak_sbox = Arc::downgrade(&sbox);
+
+        let node = <$ty>::new(weak_sbox, $storage);
+        doc.append_child(node);
+        assert_eq!(doc.child_nodes().length(), 1);
+        assert_eq!(
+            doc.first_child().unwrap().get_node_type(),
+            $node_type as isize
+        );
+
+        doc
+    }};
+}
+
+#[test]
+fn test_element_node_m() {
+    let _doc = test_node_creation!(ElementNode, NodeType::Element, ());
+}
+
+#[test]
+fn test_attr_node() {
+    let _doc = test_node_creation!(AttrNode, NodeType::Attribute, ());
+}
+
+#[test]
+fn test_text_node() {
+    let _doc = test_node_creation!(TextNode, NodeType::Text, TextNodeStorage {text: "test".to_owned()});
+
+    let node = _doc.first_child().unwrap();
+    let node = AnyNode::as_any(node.as_ref()).downcast_ref::<TextNode>().unwrap();
+
+    assert_eq!(node.get_text().unwrap(), "test".to_owned());
+}
+
+#[test]
+fn test_c_data_section_node_node() {
+    let _doc = test_node_creation!(CDataSectionNode, NodeType::CDataSection, ());
+}
+
+#[test]
+fn test_processing_instruction_node() {
+    let _doc = test_node_creation!(ProcessingInstructionNode, NodeType::ProcessingInstruction, ());
+}
+
+#[test]
+fn test_comment_node() {
+    let _doc = test_node_creation!(CommentNode, NodeType::Comment, TextNodeStorage {text: "test".to_owned()});
+}
+
+#[test]
+fn test_document_type_node() {
+    let _doc = test_node_creation!(DocumentTypeNode, NodeType::DocumentType, ());
+}
+
+#[test]
+fn test_document_fragment_node() {
+    let _doc = test_node_creation!(DocumentFragmentNode, NodeType::DocumentFragment, ());
+}
+

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -7,7 +7,7 @@ use crate::config::ScreenMetrics;
 
 use crate::node::{self, element::HtmlHtmlElement};
 use crate::node::{ AnyNode,
-    AttrNode, CDataSectionNode, CommentNode, Document, DocumentFragmentNode, DocumentTypeNode,
+    AttrNode, CDataSectionNode, CommentNode,  DocumentFragmentNode, DocumentTypeNode,
     ElementNode, NodeType, ProcessingInstructionNode, TextNode,
 };
 use crate::node::TextNodeStorage;
@@ -97,8 +97,8 @@ fn can_build_node() {
 
     let metrics: ScreenMetrics = Default::default();
     let sbox = Sandbox::new(metrics);
-    let node = sbox.builder::<node::AttrNode>().build();
-    let _: Arc<node::AttrNode> = node; // assert that we got an AttrNode
+    let node = sbox.builder::<AttrNode>().build();
+    let _: Arc<AttrNode> = node; // assert that we got an AttrNode
 
     assert!(Weak::ptr_eq(&node.get_context(), &Arc::downgrade(&sbox)));
 }


### PR DESCRIPTION
Added a get_node_type() to the ANyNode, based on the node type as defined on a DOM node, and implemented on the node creation macro.
Added all node types to the node creation Macro, with empty storage at this time. 
TODO:
1. test all nodes
2. add needed *NodeStorage classes, and attach to nodes.
3. Test storage