### PR TITLE
Ergonomics for node creation

### DIFF
--- a/src/behavior/node.rs
+++ b/src/behavior/node.rs
@@ -11,7 +11,11 @@ pub trait NodeBehavior {
     fn first_child(&self) -> Option<Arc<dyn AnyNode>>;
     fn last_child(&self) -> Option<Arc<dyn AnyNode>>;
     fn append_child(&self, other: Arc<dyn AnyNode>);
+
+    #[doc(hidden)]
+    /// RDOM-private: gives a clone of the backing children Vec
     fn static_child_nodes(&self) -> Vec<Arc<dyn AnyNode>>;
+
     fn child_nodes(&self) -> Arc<NodeList>;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 //! A Rust-based simulated DOM (browser-independent replacement for web_sys)
 
+#![feature(const_generics)]
 #![feature(arc_new_cyclic)]
 #![deny(
     missing_docs,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 //! A Rust-based simulated DOM (browser-independent replacement for web_sys)
 
-#![feature(const_generics)]
 #![feature(arc_new_cyclic)]
 #![deny(
     missing_docs,

--- a/src/nice/mod.rs
+++ b/src/nice/mod.rs
@@ -109,7 +109,7 @@ impl_nice_nodes! {
     )
     (
         Document,
-        core: node::Document,
+        core: node::DocumentNode,
         blurb: "document",
         link: "Document",
         impl {

--- a/src/node/element.rs
+++ b/src/node/element.rs
@@ -5,8 +5,9 @@ use downcast_rs::DowncastSync;
 use paste::paste;
 
 crate::use_behaviors!(node, sandbox_member);
+use crate::impl_builder;
 use crate::internal_prelude::*;
-use crate::sandbox::Sandbox;
+use crate::sandbox::{Builder, Sandbox};
 
 /// A base trait for all core element types
 pub trait AnyElement: DowncastSync + AnyNode {}
@@ -56,6 +57,8 @@ macro_rules! impl_elements {
                         construction
                     }
                 }
+
+                impl_builder!($ty);
 
                 impl_sandbox_member!($ty, member_storage);
                 impl_node!($ty, node_storage);

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -92,7 +92,7 @@ macro_rules! impl_nodes {
 }
 
 #[derive(Default, Clone)]
-pub(crate) struct DocumentStorage {
+pub(crate) struct DocumentNodeStorage {
     /// Pointer back up to the window
     pub(crate) default_view: Weak<Window>,
 }
@@ -119,8 +119,8 @@ impl_nodes! {
         impl {}
     )
     (
-        Document,
-        storage: DocumentStorage,
+        DocumentNode,
+        storage: DocumentNodeStorage,
         blurb: "document",
         link: "Document",
         impl {

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -7,6 +7,7 @@ use paste::paste;
 use crate::internal_prelude::*;
 
 crate::use_behaviors!(node, sandbox_member);
+use crate::sandbox::Builder;
 use crate::window::Window;
 
 use std::sync::{Arc, Weak};
@@ -25,6 +26,19 @@ pub trait AnyNode: DowncastSync + SandboxMemberBehavior + NodeBehavior {
     fn clone_node(&self) -> Arc<dyn AnyNode>;
 }
 impl_downcast!(sync AnyNode);
+
+#[macro_export]
+/// implements builder for type
+macro_rules! impl_builder {
+    ($ty: ident) => {
+        impl Builder<$ty> {
+            pub fn build(&self) -> Arc<$ty> {
+                #[allow(clippy::unit_arg)]
+                $ty::new(self.sandbox.clone(), Default::default())
+            }
+        }
+    };
+}
 
 macro_rules! impl_nodes {
     ($((
@@ -72,6 +86,8 @@ macro_rules! impl_nodes {
 
                     $($rest)*
                 }
+
+                impl_builder!($ty);
 
                 impl_sandbox_member!($ty, member_storage);
                 impl_node!($ty, node_storage);

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -16,36 +16,42 @@ pub(crate) struct Builder<T: AnyNode> {
 
 impl Builder<node::AttrNode> {
     pub fn build(&self) -> Arc<node::AttrNode> {
+        #[allow(clippy::unit_arg)]
         node::AttrNode::new(self.sandbox.clone(), Default::default())
     }
 }
 
 impl Builder<node::TextNode> {
     pub fn build(&self) -> Arc<node::TextNode> {
+        #[allow(clippy::unit_arg)]
         node::TextNode::new(self.sandbox.clone(), Default::default())
     }
 }
 
 impl Builder<node::DocumentNode> {
     pub fn build(&self) -> Arc<node::DocumentNode> {
+        #[allow(clippy::unit_arg)]
         node::DocumentNode::new(self.sandbox.clone(), Default::default())
     }
 }
 
 impl Builder<element::HtmlBodyElement> {
     pub fn build(&self) -> Arc<element::HtmlBodyElement> {
+        #[allow(clippy::unit_arg)]
         element::HtmlBodyElement::new(self.sandbox.clone(), Default::default())
     }
 }
 
 impl Builder<element::HtmlButtonElement> {
     pub fn build(&self) -> Arc<element::HtmlButtonElement> {
+        #[allow(clippy::unit_arg)]
         element::HtmlButtonElement::new(self.sandbox.clone(), Default::default())
     }
 }
 
 impl Builder<element::HtmlHtmlElement> {
     pub fn build(&self) -> Arc<element::HtmlHtmlElement> {
+        #[allow(clippy::unit_arg)]
         element::HtmlHtmlElement::new(self.sandbox.clone(), Default::default())
     }
 }

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -10,52 +10,9 @@ use crate::node::{self, element};
 use crate::window::Window;
 
 pub(crate) struct Builder<T: AnyNode> {
-    sandbox: Weak<Sandbox>,
+    pub(crate) sandbox: Weak<Sandbox>,
     _phantom: PhantomData<T>,
 }
-
-impl Builder<node::AttrNode> {
-    pub fn build(&self) -> Arc<node::AttrNode> {
-        #[allow(clippy::unit_arg)]
-        node::AttrNode::new(self.sandbox.clone(), Default::default())
-    }
-}
-
-impl Builder<node::TextNode> {
-    pub fn build(&self) -> Arc<node::TextNode> {
-        #[allow(clippy::unit_arg)]
-        node::TextNode::new(self.sandbox.clone(), Default::default())
-    }
-}
-
-impl Builder<node::DocumentNode> {
-    pub fn build(&self) -> Arc<node::DocumentNode> {
-        #[allow(clippy::unit_arg)]
-        node::DocumentNode::new(self.sandbox.clone(), Default::default())
-    }
-}
-
-impl Builder<element::HtmlBodyElement> {
-    pub fn build(&self) -> Arc<element::HtmlBodyElement> {
-        #[allow(clippy::unit_arg)]
-        element::HtmlBodyElement::new(self.sandbox.clone(), Default::default())
-    }
-}
-
-impl Builder<element::HtmlButtonElement> {
-    pub fn build(&self) -> Arc<element::HtmlButtonElement> {
-        #[allow(clippy::unit_arg)]
-        element::HtmlButtonElement::new(self.sandbox.clone(), Default::default())
-    }
-}
-
-impl Builder<element::HtmlHtmlElement> {
-    pub fn build(&self) -> Arc<element::HtmlHtmlElement> {
-        #[allow(clippy::unit_arg)]
-        element::HtmlHtmlElement::new(self.sandbox.clone(), Default::default())
-    }
-}
-
 /// A sandbox represents a virtual browser tab. It contains a document and a window,
 /// as well as some configuration information for screen dimensions.
 #[derive(Clone)]

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -4,7 +4,18 @@
 use crate::internal_prelude::*;
 
 use crate::config::ScreenMetrics;
+use crate::node::{self, element};
 use crate::window::Window;
+
+#[derive(PartialEq, Eq)]
+pub(crate) enum BuildableNode {
+    AttrNode,
+    TextNode,
+    DocumentNode,
+    HtmlHtmlElement,
+    HtmlBodyElement,
+    HtmlButtonElement,
+}
 
 /// A sandbox represents a virtual browser tab. It contains a document and a window,
 /// as well as some configuration information for screen dimensions.
@@ -31,5 +42,24 @@ impl Sandbox {
         // Window is safe to unwrap, as it's only None during initialization.
         // This will be fixable when arc_new_cyclic is stable.
         self.window.clone()
+    }
+
+    pub(crate) fn build_node<const N: BuildableNode>(self: Arc<Self>) -> Arc<dyn AnyNode> {
+        let sbox = Arc::downgrade(&self);
+
+        match N {
+            BuildableNode::AttrNode => node::AttrNode::new(sbox, Default::default()),
+            BuildableNode::TextNode => node::TextNode::new(sbox, Default::default()),
+            BuildableNode::DocumentNode => node::DocumentNode::new(sbox, Default::default()),
+            BuildableNode::HtmlHtmlElement => {
+                element::HtmlHtmlElement::new(sbox, Default::default())
+            }
+            BuildableNode::HtmlBodyElement => {
+                element::HtmlBodyElement::new(sbox, Default::default())
+            }
+            BuildableNode::HtmlButtonElement => {
+                element::HtmlButtonElement::new(sbox, Default::default())
+            }
+        }
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -4,10 +4,8 @@ use std::sync::Arc;
 
 use crate::behavior::node::NodeBehavior;
 use crate::config::ScreenMetrics;
-use crate::node::element::HtmlHtmlElement;
+use crate::node::{self, element::HtmlHtmlElement};
 use crate::sandbox::Sandbox;
-
-use crate::node::AnyNode;
 
 #[test]
 fn it_works() {
@@ -18,4 +16,17 @@ fn it_works() {
     let _text = doc.create_text_node("Hello, world!".to_string());
     doc.append_child(document_element);
     assert_eq!(doc.child_nodes().length(), 1);
+}
+
+#[test]
+fn can_build_node() {
+    use crate::behavior::sandbox_member::SandboxMemberBehavior;
+    use std::sync::Weak;
+
+    let metrics: ScreenMetrics = Default::default();
+    let sbox = Sandbox::new(metrics);
+    let node = sbox.builder::<node::AttrNode>().build();
+    let _: Arc<node::AttrNode> = node; // assert that we got an AttrNode
+
+    assert!(Weak::ptr_eq(&node.get_context(), &Arc::downgrade(&sbox)));
 }

--- a/src/window.rs
+++ b/src/window.rs
@@ -3,20 +3,20 @@
 use crate::internal_prelude::*;
 
 crate::use_behaviors!(sandbox_member);
-use crate::node::{Document, DocumentStorage};
+use crate::node::{DocumentNode, DocumentNodeStorage};
 
 /// A simulated window for static rendering
 pub struct Window {
     context: SandboxMemberBehaviorStorage,
-    document: Arc<Document>,
+    document: Arc<DocumentNode>,
 }
 
 impl Window {
     pub(crate) fn new(context: Weak<Sandbox>) -> Arc<Window> {
         Arc::new_cyclic(|win_weak| -> Window {
-            let document: Arc<Document> = Document::new(
+            let document: Arc<DocumentNode> = DocumentNode::new(
                 context.clone(),
-                DocumentStorage {
+                DocumentNodeStorage {
                     default_view: win_weak.clone(),
                 },
             );
@@ -28,7 +28,7 @@ impl Window {
     }
 
     /// Gets the window's document
-    pub fn document(&self) -> Arc<Document> {
+    pub fn document(&self) -> Arc<DocumentNode> {
         self.document.clone()
     }
 }


### PR DESCRIPTION
This makes it simpler to create a node; example:
```
let node = sbox.builder::<node::AttrNode>().build();
```